### PR TITLE
feat: ability to resolve references to data using templating syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# go-task/template
+
+This is a forked version of Golang's standard `text/template` package. It is
+designed to be a drop-in replacement for the original package with some
+additional features. This package was created by the Task project to fulfil
+their project-specific needs. These features are not intended to be merged into
+the original package unless they are one day deemed useful enough.
+
+## Features
+
+- `ResolveRef` - This package function will allow the user to give a blob of
+  data as they would normally to `template.Execute` and then retrieve a value
+  from that blob using go-template syntax. This solves a limitation of the
+  public API of the original package which meant that it was only ever possible
+  to return a string representation of a value in a template. This function is
+  also available as a method on the `Template` type.

--- a/template.go
+++ b/template.go
@@ -5,6 +5,7 @@
 package template
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"text/template/parse"
@@ -41,6 +42,17 @@ func New(name string) *Template {
 	}
 	t.init()
 	return t
+}
+
+func ResolveRef(ref string, data any) (any, error) {
+	if ref == "." {
+		return data, nil
+	}
+	t, err := New("resolver").Parse(fmt.Sprintf("{{%s}}", ref))
+	if err != nil {
+		return nil, err
+	}
+	return t.ResolveRef(data)
 }
 
 // Name returns the name of the template.


### PR DESCRIPTION
This PR implements a new `ResolveRef` package function that will allow the user to give a blob of data (as they would normally to `template.Execute`) and then retrieve a value from that blob using go-template syntax. This solves a limitation of the public API of the original package which meant that it was only ever possible to return a string representation of a value in a template. This function is also available as a method on the `Template` type.

```go
data := map[string]any{
	"foo": map[string]any{
		"bar": "baz",
	},
}

val, _ := template.ResolveRef(".foo.bar", data)
fmt.Println(val)
// Output: baz
```

Since any `ActionNode` is allowed, we can also use functions:

```go
data := []any{1, 2, 3, "four", "five", "six"}

val, _ := template.ResolveRef("index . 2", data)
fmt.Println(val)
// Output: 2

val, _ := template.ResolveRef("index . 5", data)
fmt.Println(val)
// Output: five
```