### PR TITLE
fix failing TestJSEscaping unprintable character

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -950,7 +950,7 @@ func TestJSEscaping(t *testing.T) {
 		{`'foo`, `\'foo`},
 		{`Go "jump" \`, `Go \"jump\" \\`},
 		{`Yukihiro says "今日は世界"`, `Yukihiro says \"今日は世界\"`},
-		{"unprintable \uFDFF", `unprintable \uFDFF`},
+		{"unprintable \uFFFE", `unprintable \uFFFE`},
 		{`<html>`, `\u003Chtml\u003E`},
 		{`no = in attributes`, `no \u003D in attributes`},
 		{`&#x27; does not become HTML entity`, `\u0026#x27; does not become HTML entity`},


### PR DESCRIPTION
fix failing TestJSEscaping unprintable character by using current val…ue from https://cs.opensource.google/go/go/+/master:src/text/template/exec_test.go

closes #2 